### PR TITLE
Fixed command passing for empty command entry

### DIFF
--- a/coreutils/BwBase.py
+++ b/coreutils/BwBase.py
@@ -2776,7 +2776,7 @@ class OWBwBWidget(widget.OWWidget):
         # iterable flags is a dict of lists of flags
         iteratedFlags = []
         if not executables:
-            return ""
+            executables = " "
         cmdStr = "bash -c '"
         if len(executables) == 1:
             cmdStr = ""


### PR DESCRIPTION
If an empty command entry is present required and optional parameters should
still be passed to the command line if an entrypoint is used.

Signed-off-by: Bob Schmitz III <14095796+rgschmitz1@users.noreply.github.com>