### PR TITLE
feature: add a password to x11vnc configuration

### DIFF
--- a/Desktop/novnc.sh
+++ b/Desktop/novnc.sh
@@ -3,5 +3,5 @@ export DISPLAY=:1
 Xvfb :1 -screen 0 1024x800x16 & 
 sleep 5
 openbox-session & xsetroot -solid "#FFFFFF" &
-x11vnc -display :1 -nopw -listen localhost -xkb -forever &
-cd /root/noVNC && ln -s vnc_lite.html index.html && ./utils/launch.sh --vnc localhost:5900 
+x11vnc -display :1 -passwd bwb -listen localhost -xkb -forever &
+cd /root/noVNC && ln -s vnc_lite.html index.html && ./utils/launch.sh --vnc localhost:5900

--- a/README.md
+++ b/README.md
@@ -345,6 +345,8 @@ docker run --rm   -p 6080:6080 \
 
    [http://localhost:6080](http://localhost:6080)
 
+***NOTE:*** the vnc password is set to **bwb**
+
 For cloud instances and remote servers use the IP of the instance or remote server instead of localhost.
 
 For Windows and Macs the IP may vary depending on your setup.

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -5,7 +5,7 @@ autostart=true
 autorestart=true
 [program:x11vnc]
 priority=20
-command=x11vnc -display :1 -forever -xkb -noxrecord -shared
+command=x11vnc -display :1 -passwd bwb -forever -xkb -noxrecord -shared
 autostart=true
 autorestart=true
 


### PR DESCRIPTION
relying on users to setup firewalls and security groups may be difficult, setting a short password for x11vnc to protect users data is the least that can be done.

Signed-off-by: Bob Schmitz III <14095796+rgschmitz1@users.noreply.github.com>