### PR TITLE
Change repo owner to lowercase for github actions

### DIFF
--- a/.github/workflows/push-latest-to-ghcr.yml
+++ b/.github/workflows/push-latest-to-ghcr.yml
@@ -7,6 +7,11 @@ jobs:
     name: Push Docker image to GitHub Container Registry
     runs-on: ubuntu-latest
     steps:
+      - name: Set lowercase owner name
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+        env:
+          OWNER: '${{ github.repository_owner }}'
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Log in to GitHub Container Registry
@@ -19,10 +24,10 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/bwb:latest
+          tags: ghcr.io/${{ env.OWNER_LC }}/bwb:latest
       - name: Push development image to GitHub Container Registry
         uses: docker/build-push-action@v2
         with:
           file: ./Dockerfile-widgets
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/bwb-dev:latest
+          tags: ghcr.io/${{ env.OWNER_LC }}/bwb-dev:latest

--- a/.github/workflows/push-published-to-ghcr.yml
+++ b/.github/workflows/push-published-to-ghcr.yml
@@ -7,6 +7,11 @@ jobs:
     name: Push Docker image to GitHub Container Registry
     runs-on: ubuntu-latest
     steps:
+      - name: Set lowercase owner name
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+        env:
+          OWNER: '${{ github.repository_owner }}'
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Log in to GitHub Container Registry
@@ -19,10 +24,10 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/bwb:${{ github.event.release.tag_name }}
+          tags: ghcr.io/${{ env.OWNER_LC }}/bwb:${{ github.event.release.tag_name }}
       - name: Push development image to GitHub Container Registry
         uses: docker/build-push-action@v2
         with:
           file: ./Dockerfile-widgets
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/bwb-dev:${{ github.event.release.tag_name }}
+          tags: ghcr.io/${{ env.OWNER_LC }}/bwb-dev:${{ github.event.release.tag_name }}


### PR DESCRIPTION
GitHub container registry expects a lowercase owner name, creating an environment variable with a lowercase owner name to use for pushing container images.

Signed-off-by: Bob Schmitz III <14095796+rgschmitz1@users.noreply.github.com>